### PR TITLE
Relax httpoison dependency to `~> 0.13 or ~> 1.0`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule HTTPoisonRetry.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:httpoison, "~> 0.13"},
+      {:httpoison, "~> 0.13 or ~> 1.0"},
       # Docs
       {:ex_doc, "~> 0.18", only: :dev},
       {:earmark, "~> 1.2", only: :dev},


### PR DESCRIPTION
Hey @mgwidmann,

Thanks for your work on httpoison_retry! We’re looking to switch AppSignal’s install process off [cURL](https://github.com/appsignal/appsignal-elixir/blob/develop/mix_helpers.exs#L90-L107) and onto HTTPoison, but need a way to retry requests (like we do now using cURL’s `—retry` flag). httpoison_retry looks like it'd be a good fit. :)

[We’ve recently relaxed our httpoison dependency](https://github.com/appsignal/appsignal-elixir/pull/322) from `~> 0.11` to `~> 0.11 or ~> 1.0` to allow newer versions of httpoison. It'd be great if httpoison_retry would also allow newer versions of httpoison, so we won't have to override the dependency on our side, if we decide to use it. :httpoison 1.x [doesn’t introduce any breaking changes](https://github.com/edgurgel/httpoison/compare/v0.13.0...master), so this patch relaxes the dependency to allow any 0.x version above 0.13, and any 1.x version.