### PR TITLE
Retries on HTTPoison.Error with reason :closed

### DIFF
--- a/lib/httpoison/retry.ex
+++ b/lib/httpoison/retry.ex
@@ -45,6 +45,8 @@ defmodule HTTPoison.Retry do
           HTTPoison.Retry.next_attempt(attempt_fn, opts)
         {:error, %HTTPoison.Error{id: nil, reason: :timeout}} ->
           HTTPoison.Retry.next_attempt(attempt_fn, opts)
+        {:error, %HTTPoison.Error{id: nil, reason: :closed}} ->
+          HTTPoison.Retry.next_attempt(attempt_fn, opts)
         # OK conditions
         {:ok, %HTTPoison.Response{status_code: 500}} ->
           HTTPoison.Retry.next_attempt(attempt_fn, opts)


### PR DESCRIPTION
Also retries the request if the connection has been closed from the host. Especially if you have a bunch of requests which should be send, the destination host sometimes closes the connection unexpected. This makes sure, that the connection is also retried, if the error reason is `:closed`.