### PR TITLE
Adds Option to Retry Any Error Reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ HTTPoison.get("https://www.example.com")
 # Will retry 5 times waiting 15s between each before returning. Therefore, your process
 # could end up waiting up to 75 seconds (plus the request time) on the line below
 # Note: below is the same as the defaults
-|> autoretry(max_attempts: 5, wait: 15_000, include_404s: false)
+|> autoretry(max_attempts: 5, wait: 15_000, include_404s: false, retry_all_errors: false)
 # Your function which will handle the response after success or failed retry
 |> handle_response()
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ HTTPoison.get("https://www.example.com")
 # Will retry 5 times waiting 15s between each before returning. Therefore, your process
 # could end up waiting up to 75 seconds (plus the request time) on the line below
 # Note: below is the same as the defaults
-|> autoretry(max_attempts: 5, wait: 15_000, include_404s: false, retry_all_errors: false)
+|> autoretry(max_attempts: 5, wait: 15_000, include_404s: false, retry_unknown_errors: false)
 # Your function which will handle the response after success or failed retry
 |> handle_response()
 ```

--- a/lib/httpoison/retry.ex
+++ b/lib/httpoison/retry.ex
@@ -14,7 +14,7 @@ defmodule HTTPoison.Retry do
       HTTPoison.get("https://www.example.com")
       # Will retry #{@max_attempts} times waiting #{@reattempt_wait / 1_000}s between each before returning
       # Note: below is the same as the defaults
-      |> autoretry(max_attempts: #{@max_attempts}, wait: #{@reattempt_wait}, include_404s: false)
+      |> autoretry(max_attempts: #{@max_attempts}, wait: #{@reattempt_wait}, include_404s: false, retry_unknown_errors: false)
       # Your function which will handle the response after success or the 5 failed retries
       |> handle_response()
 
@@ -37,7 +37,7 @@ defmodule HTTPoison.Retry do
         max_attempts: Application.get_env(:httpoison_retry, :max_attempts) || unquote(@max_attempts),
         wait: Application.get_env(:httpoison_retry, :wait) || unquote(@reattempt_wait),
         include_404s: Application.get_env(:httpoison_retry, :include_404s) || false,
-        retry_all_errors: Application.get_env(:httpoison_retry, :retry_all_errors) || false,
+        retry_unknown_errors: Application.get_env(:httpoison_retry, :retry_unknown_errors) || false,
         attempt: 1
       ], unquote(opts))
       case attempt_fn.() do
@@ -47,7 +47,7 @@ defmodule HTTPoison.Retry do
         {:error, %HTTPoison.Error{id: nil, reason: :timeout}} ->
           HTTPoison.Retry.next_attempt(attempt_fn, opts)
         {:error, %HTTPoison.Error{id: nil, reason: _}} = response ->
-          if Keyword.get(opts, :retry_all_errors) do
+          if Keyword.get(opts, :retry_unknown_errors) do
             HTTPoison.Retry.next_attempt(attempt_fn, opts)
           else
             response

--- a/test/httpoison/retry_test.exs
+++ b/test/httpoison/retry_test.exs
@@ -33,6 +33,26 @@ defmodule HTTPoison.RetryTest do
     assert 5 = Agent.get(agent, &(&1))
   end
 
+  test "errors other than nxdomain/timeout by default" do
+    {:ok, agent} = Agent.start fn -> 0 end
+    request = fn ->
+      Agent.update agent, fn(i) -> i + 1 end
+      {:error, %HTTPoison.Error{id: nil, reason: :closed}}
+    end
+    assert {:error, %HTTPoison.Error{id: nil, reason: :closed}} = autoretry(request.())
+    assert 1 = Agent.get(agent, &(&1))
+  end
+
+  test "include other error types" do
+    {:ok, agent} = Agent.start fn -> 0 end
+    request = fn ->
+      Agent.update agent, fn(i) -> i + 1 end
+      {:error, %HTTPoison.Error{id: nil, reason: :closed}}
+    end
+    assert {:error, %HTTPoison.Error{id: nil, reason: :closed}} = autoretry(request.(), retry_all_errors: true)
+    assert 5 = Agent.get(agent, &(&1))
+  end
+
   test "404s by default" do
     {:ok, agent} = Agent.start fn -> 0 end
     request = fn ->

--- a/test/httpoison/retry_test.exs
+++ b/test/httpoison/retry_test.exs
@@ -49,7 +49,7 @@ defmodule HTTPoison.RetryTest do
       Agent.update agent, fn(i) -> i + 1 end
       {:error, %HTTPoison.Error{id: nil, reason: :closed}}
     end
-    assert {:error, %HTTPoison.Error{id: nil, reason: :closed}} = autoretry(request.(), retry_all_errors: true)
+    assert {:error, %HTTPoison.Error{id: nil, reason: :closed}} = autoretry(request.(), retry_unknown_errors: true)
     assert 5 = Agent.get(agent, &(&1))
   end
 


### PR DESCRIPTION
Hey Matt, 

First of all, thanks for the great library - simple and useful :)

Not sure if this PR is something your interested in or not, so feel free to close without comment, but we needed this change for some http errors we are seeing in our system like, `ehostunreach`, `econnrefused`, and `closed`, and I thought I'd offer the upstream change.

If you have any suggestions for doing this differently, I'd be open to make the changes too.

Thanks again! 

- Adds new option `retry_all_errors` to retry HTTPoison requests
  that fail with any error reason 
- Backwards compatible to only retry nxdomain and timeout
  errors by default
- Works just like the include_404s option