### PR TITLE
User definable HTTP status codes, error reasons, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ HTTPoison.get("https://www.example.com")
 # Will retry 5 times waiting 15s between each before returning. Therefore, your process
 # could end up waiting up to 75 seconds (plus the request time) on the line below
 # Note: below is the same as the defaults
-|> autoretry(max_attempts: 5, wait: 15_000, include_404s: false, retry_unknown_errors: false)
+|> autoretry(max_attempts: 5, wait: 15_000, status_codes: [500], retry_unknown_errors: false,
+             error_reasons: [:nxdomain, :timeout, :closed])
 # Your function which will handle the response after success or failed retry
 |> handle_response()
 ```

--- a/lib/httpoison/retry.ex
+++ b/lib/httpoison/retry.ex
@@ -70,8 +70,8 @@ defmodule HTTPoison.Retry do
     opts[:max_attempts] == :infinity or attempt < opts[:max_attempts]
   end
 
-  def wait(n, _) when is_integer(n), do: Process.sleep(n)
-  def wait(:exponential, attempt) do
+  defp wait(n, _) when is_integer(n), do: Process.sleep(n)
+  defp wait(:exponential, attempt) do
     # This has the potential to sleep for very long times, and should be
     # capped, or the maximum should be controllable
     Process.sleep(:random.uniform(1 <<< attempt) * 1000)

--- a/lib/httpoison/retry.ex
+++ b/lib/httpoison/retry.ex
@@ -16,7 +16,8 @@ defmodule HTTPoison.Retry do
       HTTPoison.get("https://www.example.com")
       # Will retry #{@max_attempts} times waiting #{@reattempt_wait / 1_000}s between each before returning
       # Note: below is the same as the defaults
-      |> autoretry(max_attempts: #{@max_attempts}, wait: #{@reattempt_wait}, include_404s: false, retry_unknown_errors: false)
+      |> autoretry(max_attempts: #{@max_attempts}, wait: #{@reattempt_wait}, status_codes: [500], retry_unknown_errors: false,
+                   error_reasons: [:nxdomain, :timeout, :closed])
       # Your function which will handle the response after success or the 5 failed retries
       |> handle_response()
 

--- a/lib/httpoison/retry.ex
+++ b/lib/httpoison/retry.ex
@@ -65,6 +65,7 @@ defmodule HTTPoison.Retry do
   defp retry?({:ok, %HTTPoison.Response{status_code: status_code}}, opts) do
     status_code in opts[:status_codes]
   end
+  defp retry?(_, _), do: false
 
   defp next_attempt?(attempt, opts) do
     opts[:max_attempts] == :infinity or attempt < opts[:max_attempts]

--- a/test/httpoison/retry_test.exs
+++ b/test/httpoison/retry_test.exs
@@ -69,7 +69,7 @@ defmodule HTTPoison.RetryTest do
       Agent.update agent, fn(i) -> i + 1 end
       {:ok, %HTTPoison.Response{status_code: 404}}
     end
-    assert {:ok, %HTTPoison.Response{status_code: 404}} = autoretry(request.(), include_404s: true)
+    assert {:ok, %HTTPoison.Response{status_code: 404}} = autoretry(request.(), status_codes: [500, 404])
     assert 5 = Agent.get(agent, &(&1))
   end
 


### PR DESCRIPTION
Hello,

I'd like to present this pull request as a source for ideas, not necessarily as an as-is change. It is both quite a substantial refactoring, and backwards incompatible:

 * `:include_404` removed

The main driver was the desire to give users more control over which HTTP status codes can be retried, but then I got carried away. The end result is:

  * HTTP status codes to retry entirely user controllable using `:status_codes`
  * The same applies to error reasons using `:error_reasons`
  * The main macro is now only a simple wrapper to the (new) functional API
  * `opts` only built once per call to `autoretry/2`
  * The recursion is now simple recursion, instead of mutual recursion including a macro (that to me looked like it wrapped the wrapper, etc.)
  * `:wait` supports `:exponential`, a simple implementation of the idea with some caveats for the time being (this might step a bit too much in to the domain of ElixirRetry)